### PR TITLE
允许在上传/下载开始之后继续添加新的listener

### DIFF
--- a/app/src/main/java/me/jessyan/progressmanager/demo/AdvanceActivity.java
+++ b/app/src/main/java/me/jessyan/progressmanager/demo/AdvanceActivity.java
@@ -278,7 +278,7 @@ public class AdvanceActivity extends AppCompatActivity implements View.OnClickLi
                 } catch (IOException e) {
                     e.printStackTrace();
                     //当外部发生错误时,使用此方法可以通知所有监听器的 onError 方法
-                    ProgressManager.getInstance().notifyOnErorr(mNewUploadUrl, e);
+                    ProgressManager.getInstance().notifyOnError(mNewUploadUrl, e);
                 }
             }
         }).start();
@@ -317,7 +317,7 @@ public class AdvanceActivity extends AppCompatActivity implements View.OnClickLi
                 } catch (IOException e) {
                     e.printStackTrace();
                     //当外部发生错误时,使用此方法可以通知所有监听器的 onError 方法
-                    ProgressManager.getInstance().notifyOnErorr(mNewDownloadUrl, e);
+                    ProgressManager.getInstance().notifyOnError(mNewDownloadUrl, e);
                 }
             }
         }).start();

--- a/app/src/main/java/me/jessyan/progressmanager/demo/MainActivity.java
+++ b/app/src/main/java/me/jessyan/progressmanager/demo/MainActivity.java
@@ -291,7 +291,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 } catch (IOException e) {
                     e.printStackTrace();
                     //当外部发生错误时,使用此方法可以通知所有监听器的 onError 方法
-                    ProgressManager.getInstance().notifyOnErorr(mUploadUrl, e);
+                    ProgressManager.getInstance().notifyOnError(mUploadUrl, e);
                 }
             }
         }).start();
@@ -330,7 +330,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 } catch (IOException e) {
                     e.printStackTrace();
                     //当外部发生错误时,使用此方法可以通知所有监听器的 onError 方法
-                    ProgressManager.getInstance().notifyOnErorr(mDownloadUrl, e);
+                    ProgressManager.getInstance().notifyOnError(mDownloadUrl, e);
                 }
             }
         }).start();

--- a/progress/src/main/java/me/jessyan/progressmanager/body/ProgressRequestBody.java
+++ b/progress/src/main/java/me/jessyan/progressmanager/body/ProgressRequestBody.java
@@ -19,7 +19,7 @@ import android.os.Handler;
 import android.os.SystemClock;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 
 import me.jessyan.progressmanager.ProgressListener;
 import okhttp3.MediaType;
@@ -44,12 +44,12 @@ public class ProgressRequestBody extends RequestBody {
     protected Handler mHandler;
     protected int mRefreshTime;
     protected final RequestBody mDelegate;
-    protected final List<ProgressListener> mListeners;
+    protected final Set<ProgressListener> mListeners;
     protected final ProgressInfo mProgressInfo;
     private BufferedSink mBufferedSink;
 
 
-    public ProgressRequestBody(Handler handler, RequestBody delegate, List<ProgressListener> listeners, int refreshTime) {
+    public ProgressRequestBody(Handler handler, RequestBody delegate, Set<ProgressListener> listeners, int refreshTime) {
         this.mDelegate = delegate;
         this.mListeners = listeners;
         this.mHandler = handler;
@@ -82,8 +82,8 @@ public class ProgressRequestBody extends RequestBody {
             mBufferedSink.flush();
         } catch (IOException e) {
             e.printStackTrace();
-            for (int i = 0; i < mListeners.size(); i++) {
-                mListeners.get(i).onError(mProgressInfo.getId(), e);
+            for (ProgressListener listener:mListeners) {
+                listener.onError(mProgressInfo.getId(), e);
             }
             throw e;
         }
@@ -104,8 +104,8 @@ public class ProgressRequestBody extends RequestBody {
                 super.write(source, byteCount);
             } catch (IOException e) {
                 e.printStackTrace();
-                for (int i = 0; i < mListeners.size(); i++) {
-                    mListeners.get(i).onError(mProgressInfo.getId(), e);
+                for (ProgressListener listener:mListeners) {
+                    listener.onError(mProgressInfo.getId(), e);
                 }
                 throw e;
             }
@@ -120,8 +120,7 @@ public class ProgressRequestBody extends RequestBody {
                     final long finalTempSize = tempSize;
                     final long finalTotalBytesRead = totalBytesRead;
                     final long finalIntervalTime = curTime - lastRefreshTime;
-                    for (int i = 0; i < mListeners.size(); i++) {
-                        final ProgressListener listener = mListeners.get(i);
+                    for (final ProgressListener listener:mListeners) {
                         mHandler.post(new Runnable() {
                             @Override
                             public void run() {

--- a/progress/src/main/java/me/jessyan/progressmanager/body/ProgressResponseBody.java
+++ b/progress/src/main/java/me/jessyan/progressmanager/body/ProgressResponseBody.java
@@ -19,7 +19,7 @@ import android.os.Handler;
 import android.os.SystemClock;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 
 import me.jessyan.progressmanager.ProgressListener;
 import okhttp3.MediaType;
@@ -44,11 +44,11 @@ public class ProgressResponseBody extends ResponseBody {
     protected Handler mHandler;
     protected int mRefreshTime;
     protected final ResponseBody mDelegate;
-    protected final List<ProgressListener> mListeners;
+    protected final Set<ProgressListener> mListeners;
     protected final ProgressInfo mProgressInfo;
     private BufferedSource mBufferedSource;
 
-    public ProgressResponseBody(Handler handler, ResponseBody responseBody, List<ProgressListener> listeners, int refreshTime) {
+    public ProgressResponseBody(Handler handler, ResponseBody responseBody, Set<ProgressListener> listeners, int refreshTime) {
         this.mDelegate = responseBody;
         this.mListeners = listeners;
         this.mHandler = handler;
@@ -87,8 +87,8 @@ public class ProgressResponseBody extends ResponseBody {
                     bytesRead = super.read(sink, byteCount);
                 } catch (IOException e) {
                     e.printStackTrace();
-                    for (int i = 0; i < mListeners.size(); i++) {
-                        mListeners.get(i).onError(mProgressInfo.getId(), e);
+                    for (ProgressListener listener:mListeners) {
+                        listener.onError(mProgressInfo.getId(), e);
                     }
                     throw e;
                 }
@@ -105,8 +105,7 @@ public class ProgressResponseBody extends ResponseBody {
                         final long finalTempSize = tempSize;
                         final long finalTotalBytesRead = totalBytesRead;
                         final long finalIntervalTime = curTime - lastRefreshTime;
-                        for (int i = 0; i < mListeners.size(); i++) {
-                            final ProgressListener listener = mListeners.get(i);
+                        for (final ProgressListener listener:mListeners) {
                             mHandler.post(new Runnable() {
                                 @Override
                                 public void run() {


### PR DESCRIPTION
之前是必须在网络请求之前添加好所有的listener，但是有些场景需要在网络请求之后还可以添加新的listener。
比如常见的应用市场，app列表页面每一个item会有一个下载按钮，点击后开始下载并显示进度，而点击item进入详情页也会有一个带进度的下载按钮，如果先在列表页面点击了下载，再进入详情页，详情页也应该和列表页同步地获取到进度信息。
主要改动是ProgressRequestBody和ProgressResponseBody中的mListeners由数组改为List，与ProgressManager中的listener指向相同的内存地址，同时构造函数中的listeners也不再有null的情况，在ProgressManager的wrap方法中，如果根据url获取到的listeners为null，会put进去一个空的List并传给ProgressRequestBody/ProgressResponseBody。